### PR TITLE
Complete rewrite of the standard levels. See https://github.com/mozil…

### DIFF
--- a/Security/Scoring_and_other_levels.mediawiki
+++ b/Security/Scoring_and_other_levels.mediawiki
@@ -1,0 +1,192 @@
+<!--
+Levels you can copy paste in HTML and other documents
+
+Pass/Fail
+<span style="background-color: #14892c; border-radius: .25em; color: #ffffff; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">PASS</span>
+<span style="background-color: #d04437; border-radius: .25em; color: #ffffff; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">FAIL</span>
+
+Document status
+<span style="background-color: #14892c; border-radius: .25em; color: #ffffff; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">READY</span>
+<span style="background-color: #ffd351; border-radius: .25em; color: #594300; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">DRAFT</span>
+<span style="background-color: #d04437; border-radius: .25em; color: #ffffff; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">NOT READY</span>
+
+
+Optional, Should, Must
+<span style="background-color: #cccccc; border-radius: .25em; color: #000000; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">OPTIONAL</span>
+<span style="background-color: #ffd351; border-radius: .25em; color: #594300; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">SHOULD</span>
+<span style="background-color: #d04437; border-radius: .25em; color: #ffffff; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">MUST</span>
+
+Scoring A-F
+<span style="background-color: #14892c; border-radius: .25em; color: #ffffff; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">A+, A</span>
+<span style="background-color: #4a6785; border-radius: .25em; color: #ffffff; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">B</span>
+<span style="background-color: #ffd351; border-radius: .25em; color: #594300; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">C</span>
+<span style="background-color: #d04437; border-radius: .25em; color: #ffffff; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">F</span>
+-->
+<table>
+  <tr>
+    <td style="min-width: 25em;">__TOC__</td>
+    <td style="vertical-align: top; padding-left: 1em;">
+<span style="background-color: #14892c; border-radius: .25em; color: #ffffff; display: inline-block; font-weight: bold;
+-margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">READY</span>
+
+The goal of this document is to ensure consistency, coherence between security documents. All Mozilla
+security documentation should follow the recommendations below.
+
+The Enterprise Information Security (Infosec, formerly OpSec) team maintains this document as a reference guide for operational teams.
+
+Updates to this page should be submitted to the [https://github.com/mozilla/wikimo_opsec/ source repository on github].
+Changes are detailed in the [https://github.com/mozilla/wikimo_opsec/commits/master commit history].
+
+<span style="float: right; padding-top: 3em;">[[File:OpSec.png|300px]]</span>
+    </td>
+  </tr>
+</table>
+
+== Scoring and other levels ==
+
+These levels should be used when possible.
+
+=== RFC2119 handling recommendation levels ===
+See also [https://www.ietf.org/rfc/rfc2119.txt RFC 2119] for a formal definition.
+
+{| class="wikitable"
+|-
+! Level
+! Expectations
+|-
+|-
+! <span style="background-color: #cccccc; border-radius: .25em; color: #000000; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">OPTIONAL</span>
+|
+* This is up to the reader to choose to follow or not to follow this recommendation.
+|-
+! <span style="background-color: #ffd351; border-radius: .25em; color: #594300; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">SHOULD</span>
+|
+* Should is very close to "must do" - however, exceptions may be granted after discussion.
+|-
+! <span style="background-color: #d04437; border-radius: .25em; color: #ffffff; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">MUST</span>
+|
+* This must be done, is required, mandatory - there is no exception.
+|-
+|}
+
+=== Recommended configuration states ===
+These are used to match recommended configuration states. It describes set of documentation configuration state that we recommend using, depending on your use-case.
+
+
+{| class="wikitable"
+|-
+! Level
+! Expectations
+|-
+! <span style="background-color: #cccccc; border-radius: .25em; color: #000000; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">Modern</span>
+|
+* State of the art configuration from a security point of view.
+* Generally better for security sensitive services.
+* Fewer server/clients may be compatible.
+|-
+! <span style="background-color: #ffd351; border-radius: .25em; color: #594300; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">Intermediate</span>
+|
+* Usually the default configuration we recommend.
+* Reasonable configuration that we recommend while covering the largest amount of clients.
+* Fewer server/clients may be compatible, though the majority should be compatible with this configuration.
+|-
+! <span style="background-color: #d04437; border-radius: .25em; color: #ffffff; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">Old</span>
+|
+* Configuration that you may only use if other configurations cannot be followed for technical reasons
+* Relatively safe - but must be moved to the ''intermediate'' configuration above when possible.
+* Generally supports the largest amount of servers/clients.
+|-
+|}
+
+=== Document Status Codes ===
+These are used in the header of every document to clearly signify its current status.
+
+{| class="wikitable"
+|-
+! Level
+! Expectations
+|-
+! <span style="background-color: #14892c; border-radius: .25em; color: #ffffff; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">READY</span>
+|
+* Means the document is ready for user consumption and is expected to be followed.
+|-
+! <span style="background-color: #ffd351; border-radius: .25em; color: #594300; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">DRAFT</span>
+|
+* Means the document is in progress or does not cover all cases.
+* You may follow this document for guidance, at your own risk.
+|-
+! <span style="background-color: #d04437; border-radius: .25em; color: #ffffff; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">NOT READY</span>
+|
+* Means the document should not be followed right now.
+|-
+|}
+
+=== Pass/fail tests ===
+Tests are not levels per se. When possible, they either pass or fail. It's similar to a walk/don't walk traffic sign.
+
+{| class="wikitable"
+|-
+! Level
+! Coding rationale
+! Expectations
+|-
+! <span style="background-color: #14892c; border-radius: .25em; color: #ffffff; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">PASS</span>
+|
+* Green generally means acceptance, allowance such as the traffic sign "Walk".
+|
+* Means a test successfully passed.
+* There is no "almost passed": test must completely pass.
+|-
+! <span style="background-color: #d04437; border-radius: .25em; color: #ffffff; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">FAIL</span>
+|
+* Red generally means refusal, denial, such as the traffic sign "Don't walk".
+|
+* Means a test did not pass.
+|-
+|}
+
+=== Scoring levels  ===
+
+Scores are used to gamify usage of security controls and features.
+Note these levels do not directly signify risk, and are instead intended to provide a grade for a particular objective. The mapping to objective can be used as a base to create a mapping to [[Security/Standard_Levels]].
+
+The letter '''E''' is not used in the grades in order to keep scores concise and voluntarily less granular (see expectations for each grade below).
+The use of '''+''' and '''-''' modifiers is allowed if necessary. These are added to represent going slightly above or below expectations.
+
+{| class="wikitable"
+|-
+! Level
+! Expectations
+|-
+! <span style="background-color: #14892c; border-radius: .25em; color: #ffffff; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">A+, A, A-</span>
+|
+''Highest possible grade''.
+
+* Support all features and controls.
+* All intentions of objective met.
+|-
+! <span style="background-color: #4a6785; border-radius: .25em; color: #ffffff; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">B+, B, B-</span>
+|
+* Supports most important features and controls.
+* Some outliers need attention.
+* Most intentions of objective met.
+|-
+! <span style="background-color: #ffd351; border-radius: .25em; color: #594300; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">C+, C, C-</span>
+
+<span style="background-color: #ffd351; border-radius: .25em; color: #594300; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">D+, D, D-</span>
+|
+''Score may moderately contribute to risk''.
+
+* Potential service blocker.
+* Needs attention and features need to be enabled/controls added.
+* Minimal to moderation intentions of objective met.
+|-
+! <span style="background-color: #d04437; border-radius: .25em; color: #ffffff; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">F</span>
+|
+''Lowest possible grade, score may greatly contribute to risk''.
+
+* Zero to minimal intentions of objective met.
+* Immediate attention and action are required.
+* Score likely to block the service.
+|-
+|}

--- a/Security/Standard_Levels.mediawiki
+++ b/Security/Standard_Levels.mediawiki
@@ -1,48 +1,31 @@
 <!-- Levels colors reference for copy pasting -->
 <!--
-Levels
+Levels you can copy paste in HTML documents
+
 <span style="background-color: #ffffff; border: solid 1px #aaaaaa; border-radius: .25em; color: #000000; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">UNKNOWN</span>
 <span style="background-color: #cccccc; border-radius: .25em; color: #000000; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">LOW</span>
 <span style="background-color: #4a6785; border-radius: .25em; color: #ffffff; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">MEDIUM</span>
 <span style="background-color: #ffd351; border-radius: .25em; color: #594300; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">HIGH</span>
 <span style="background-color: #d04437; border-radius: .25em; color: #ffffff; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">MAXIMUM</span>
-
-Pass/Fail
-<span style="background-color: #14892c; border-radius: .25em; color: #ffffff; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">PASS</span>
-<span style="background-color: #d04437; border-radius: .25em; color: #ffffff; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">FAIL</span>
-
-Document status
-<span style="background-color: #14892c; border-radius: .25em; color: #ffffff; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">READY</span>
-<span style="background-color: #ffd351; border-radius: .25em; color: #594300; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">DRAFT</span>
-<span style="background-color: #d04437; border-radius: .25em; color: #ffffff; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">NOT READY</span>
-
-Star rating
-<span style="background-color: #14892c; border-radius: .25em; color: #ffffff; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">✯✯✯✯</span>
-<span style="background-color: #4a6785; border-radius: .25em; color: #000000; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">✯✯✯</span>
-<span style="background-color: #ffd351; border-radius: .25em; color: #594300; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">✯✯</span>
-<span style="background-color: #d04437; border-radius: .25em; color: #ffffff; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">✯</span>
-
-Optional, Should, Must
-<span style="background-color: #cccccc; border-radius: .25em; color: #000000; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">OPTIONAL</span>
-<span style="background-color: #ffd351; border-radius: .25em; color: #594300; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">SHOULD</span>
-<span style="background-color: #d04437; border-radius: .25em; color: #ffffff; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">MUST</span>
  -->
+
 <table>
   <tr>
     <td style="min-width: 25em;">__TOC__</td>
     <td style="vertical-align: top; padding-left: 1em;">
-'''STATUS: <span style="background-color: #14892c; border-radius: .25em; color: #ffffff; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">READY</span>'''
+<span style="background-color: #14892c; border-radius: .25em; color: #ffffff; display: inline-block; font-weight: bold;
+margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">READY</span>
 
 The goal of this document is to ensure consistency, coherence between security documents. All Mozilla
 security documentation must follow the recommendations below.
 
-'''If a level is not present in this document, it cannot be used.'''
+'''If a risk level is not present in this document, it cannot be used to express security risk.'''
 
 It establishes standard level conventions, in particular:
 
 * Level color coding
 * Name or name schemes
-* Level definition
+* Level expectation
 
 The Enterprise Information Security (Infosec, formerly OpSec) team maintains this document as a reference guide for operational teams.
 
@@ -55,296 +38,120 @@ Changes are detailed in the [https://github.com/mozilla/wikimo_opsec/commits/mas
 </table>
 
 = Standard Documentation Levels =
-== Different kinds of levels ==
-There are different kind of levels or states we want to express:
 
-* Risk levels
-* Data handling levels
-* Not-strictly-levels tests such as "OK" or "PASS" and "NON-OK/NOK", "FAIL"
-* Scoring levels such as "good", "bad"
-* Requirement levels
-* etc.
+We strongly focus on presenting risk levels in all documents, pages, etc. It allows for a common representation of risk regardless of tools and other nomenclature used.
+If you use a scoring system for example, and your score is F, you are at higher risk. If data is of higher level, you are at higher risk. Etc.
+For this reason, the risk levels are the most important levels and '''must''' always be followed and present.
 
-While they're used to describe different kind of levels, they all attempt to ''display a hierarchy''. Thus, all levels
-attempt to use the same coherent standard model.
+{| class="wikitable"
+|-
+! <span style="color:Gray;">'''Scoring, pass/fail, RFC2119, etc.'''</span>
+|-
+|
+If you are looking for scoring, pass/fail, document readiness, etc. labels and levels, please check [[User:Security/Scoring_and_other_levels|Scoring and other levels]] instead.
 
-== Risk levels definition and nomenclature ==
+Do note that all document '''must''' also express risk.
+|}
 
-These are the base standard levels and are strongly encouraged be used as a foundation for any other level definition.
+== Standard risk levels definition and nomenclature ==
+''The risk levels also represent a simplified ISO 31000 equivalent (and are non-compliant) .''
+These levels are also used to display risk impact, risk probability and any risk related level.
 
 {| class="wikitable"
 |-
 ! Risk Level
-| '''The importance of a risk as defined by its impact and probability.'''
-We express security risk levels qualitatively (low, medium, high, maximum).
+! Expectations
+! Rationale
 |-
-! Risk mitigation
-| Reduce the risk level through a technical or non-technical mean in order to:
-* Change its impact.
-* Change its probability.
-|-
-! Risk remediation
-| Remove the risk by correcting an issue, or removing the issue, or implementing a technical or non-technical solution that removes the risk.
-|-
-! Residual risk
-Accepted risk
-| Risk that will not be corrected, removed or reduced. It is instead accepted as-is and will therefore be residual.
-|-
-|}
+! <span style="background-color: #d04437; border-radius: .25em; color: #ffffff; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">MAXIMUM Risk</span>
+| ''This is the most important level, where the risk is especially great.''
 
-''The risk levels are not ISO 31000 compliant, but represent a relatively simplified equivalent. (If you do not know ISO 31000, that's fine!).''
-
-{| class="wikitable"
-|-
-! Level
-! Coding rationale
-! Definition & expectations
-|-
-! <span style="background-color: #ffffff; border: solid 1px #aaaaaa; border-radius: .25em; color: #000000; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">UNKNOWN</span>
-| White represent the emptiness/lack of data.
-| This is '''not a real level''', it is used when there to represent that we do not have enough data to correctly assess risk (i.e. data collection work is required).
-Even when no data is present, it is often possible to estimate the risk (since there is a risk of ''not knowing'').
-
-However, communicating the risk of not knowing is challenging and prone to failure, in particular when once data has been gathered, the risk appears to in fact be low.
-
-This concept is also known as ''"trust, but verify"'' - i.e. unknown does not dist-trust (by assign it a higher risk) the service, user, etc. by default.
-|-
-! <span style="background-color: #cccccc; border-radius: .25em; color: #000000; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">LOW</span>
-|
-* Gray is a low contrast color, which signifies important. It's also less catchy.
-* Green is not used as green means "ok to do", which is not a level.
-|''This is the lowest level, where the risk is reasonably close to zero.''
-
-* '''Attention''': Attention is expected but not required.
-* '''Complexity''': No specific tooling or strategies required. Following security practices with security level low is expected.
-* '''Effort''': If any is necessary - ''best effort'' is expected to mitigate or remediate the risk.
-* '''Risk acceptance''': Risk may often be accepted as residual risk.
-* '''Exception time''': Indefinitely.
-|-
-! <span style="background-color: #4a6785; border-radius: .25em; color: #ffffff; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">MEDIUM</span>
-|
-* Blue is calm and neutral.
-|
-* '''Attention''': Get attention from all concerned parties.
-* '''Complexity''': Following security practices with security level medium is expected.
-* '''Effort''': Industry best practices are expected to be followed in all cases.
-* '''Risk acceptance''': Risk should generally be discussed, and at least mitigated.
-* '''Exception time''': Recommend remediation within 90-180 days.
-|-
-! <span style="background-color: #ffd351; border-radius: .25em; color: #594300; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">HIGH</span>
-|
-* Yellow generally signifies "warning". In our case it correlates to "important".
-|
-* '''Attention''': Get full attention from all concerned parties.
-* '''Complexity''': Following practices with security level high is expected. Slightly advanced configuration settings and extra tools may be used.
-* '''Effort''': ''A larger amount of effort'' is expected.
-* '''Risk acceptance''': Risk must  be discussed, and should at least be mitigated.
-* '''Exception time''': Recommend remediation within 30-90 days.
-|-
-! <span style="background-color: #d04437; border-radius: .25em; color: #ffffff; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">MAXIMUM</span>
+* '''Attention''':  Full attention from all concerned parties required.
+* '''Impact''': High or maximum impact.
+* '''Effort''': All resources engaged on fixing issues. Following standard/guidelines is required.
+* '''Risk acceptance''': Rarely accepted as residual risk, must be discussed, and must be mitigated or remediated.
+* '''Exception time (SLA)''': Recommend fixing '''immediately'''.
 |
 * Red signifies "most important".
 * Maximum is a level. Critical is not.
-| ''This is the most important level, where the risk is especially great.''
+|-
+! <span style="background-color: #ffd351; border-radius: .25em; color: #594300; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">HIGH Risk</span>
+|
+* '''Attention''': Full attention from all concerned parties required.
+* '''Impact''': Medium, high or maximum impact.
+* '''Effort''': Some key resources engaged on fixing the issue. Following standard/guidelines is required.
+* '''Risk acceptance''': Risk must be discussed, and must at least be mitigated.
+* '''Exception time (SLA)''': Recommend remediation within '''7 days'''.
+|
+* Yellow generally signifies "warning". In our case it correlates to "important".
+|-
+! <span style="background-color: #4a6785; border-radius: .25em; color: #ffffff; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">MEDIUM Risk</span>
+|
+* '''Attention''': Attention from all concerned parties.
+* '''Impact''': Low, medium or high impact.
+* '''Effort''': ''Best effort''. Following standard/guidelines is required.
+* '''Risk acceptance''': Risk should be discussed, and at least mitigated.
+* '''Exception time (SLA)''': Recommend remediation within '''90 days'''.
+|
+* Blue is calm and neutral.
+|-
+! <span style="background-color: #cccccc; border-radius: .25em; color: #000000; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">LOW Risk</span>
+|
+* '''Attention''': Expected but not required.
+* '''Impact''': Low or medium impact.
+* '''Effort''': ''Best effort'' and '''best practices''' expected.
+* '''Risk acceptance''': Risk may often be accepted as residual risk.
+* '''Exception time (SLA)''': Indefinitely.
+|
+* Gray is a low contrast color, which signifies not too important. It's also less catchy.
+* Green is not used as green means "ok to do", which is not a level.
+|-
+! <span style="background-color: #ffffff; border: solid 1px #aaaaaa; border-radius: .25em; color: #000000; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">UNKNOWN Risk</span>
+|
+* Data collection is expected.
+* This level is expected to change to one of the other levels.
+|
+* White represent the emptiness/lack of data.
+This is '''not a true level''', it is used when there to represent that we do not have enough data to correctly assess the level (i.e. data collection work is required).
 
-* '''Attention''': Get full attention from all concerned parties
-* '''Complexity''': Following practices with security level maximum is expected. Uses the best and most advanced available remediation or mitigation strategies, tools.
-* '''Effort''': Greatest amount of effort is required to mitigate or remediate the risk.
-* '''Risk acceptance''': This risk is rarely expected to be accepted as residual risk, must be discussed, and should be mitigated or remediated.
-* '''Exception time''': Recommend fixing immediately.
+Note: communicating the risk of not knowing is challenging and prone to failure, in particular when once data has been gathered, the risk appears to in fact be low.
+
+This concept is also known as ''"trust, but verify"'' - i.e. unknown does not distrust (by assign it a higher risk) the service, user, etc. by default.
 |-
 |}
 
-== Effort measurements ==
-When work is required for a remediation, mitigation, additional security control, etc. we rate this effort using our standard levels. This helps managing resources and prioritizing work.
+== Examples of usage  ==
 
 {| class="wikitable"
 |-
 ! Level
-! Time spent
+! Example
 |-
-! <span style="background-color: #cccccc; border-radius: .25em; color: #000000; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">LOW</span>
+! <span style="background-color: #cccccc; border-radius: .25em; color: #000000; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">LOW Risk</span>
 |
-* Small group: Few hours.
-* Large group: Few minutes.
-
-Example: Flip a configuration switch, change a password, lookup a document, etc.
+* '''Attention''': Service owner or delivery team may look at it, through email or other means.
+* '''Effort''': Flip a configuration switch, change a password, lookup a document, etc.
+* '''Risk acceptance''': Accept risk of leaking non-sensitive data as peer-review process is light.
 |-
-! <span style="background-color: #4a6785; border-radius: .25em; color: #ffffff; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">MEDIUM</span>
+! <span style="background-color: #4a6785; border-radius: .25em; color: #ffffff; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">MEDIUM Risk</span>
 |
-* Small group: A few days.
-* Large group: A few hours.
-
-Example: Take a group decision, create standards, lookup complex data, manual upgrades, etc.
+* '''Attention''': Service owner or delivery team must be informed via bug, document, etc.
+* '''Effort''': Take a group decision, create standards, lookup statistics, manual upgrades, etc.
+* '''Risk acceptance''': Mitigate the risk of attackers accessing the admin panel by using SSO.
 |-
-! <span style="background-color: #ffd351; border-radius: .25em; color: #594300; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">HIGH</span>
+! <span style="background-color: #ffd351; border-radius: .25em; color: #594300; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">HIGH Risk</span>
 |
-* Small group: A week or two.
-* Large group: A day or two.
-
-Example: Implement a new security control, code a new feature, change all company user passwords, etc.
+* '''Attention''': Ensure service, product owner is aware via bug and pings.
+* '''Effort''': Implement a new security control, code a new feature, change all company user passwords, etc.
+* '''Risk acceptance''': Hotfix to mitigate within the next few days, eventually turn off if it takes too long.
 |-
-! <span style="background-color: #d04437; border-radius: .25em; color: #ffffff; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">MAXIMUM</span>
+! <span style="background-color: #d04437; border-radius: .25em; color: #ffffff; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">MAXIMUM Risk</span>
 |
-* Small group: Weeks, quarterly goals.
-* Large group: Weeks, quarterly goals.
-
-Example: Implement a new security design/change product design, etc.
+* '''Attention''': Ensure service,product, capability owner is aware via bug and pings.
+* '''Effort''': Implement a new security design/change product design, etc.
+* '''Risk acceptance''': Turn service off/put it behind VPN until fixed/ASAP.
 |-
 |}
 
-== RFC2119 handling recommendation levels ==
-See also [https://www.ietf.org/rfc/rfc2119.txt RFC 2119] for a formal definition.
-
-{| class="wikitable"
-|-
-! Level
-! Coding rationale
-! Definition & expectations
-|-
-|-
-! <span style="background-color: #cccccc; border-radius: .25em; color: #000000; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">OPTIONAL</span>
-|
-* See risk level's [[#Risk levels definition and nomenclature | "low"]] rationale.
-|
-* This is up to the reader to choose to follow or not to follow this recommendation.
-|-
-! <span style="background-color: #ffd351; border-radius: .25em; color: #594300; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">SHOULD</span>
-|
-* See risk level's [[#Risk levels definition and nomenclature | "high"]] rationale.
-|
-* Should is very close to "must do" - however, exceptions may be granted after discussion.
-|-
-! <span style="background-color: #d04437; border-radius: .25em; color: #ffffff; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">MUST</span>
-|
-* See risk level's [[#Risk levels definition and nomenclature | "maximum"]] rationale.
-|
-* This must be done, is required, mandatory - there is no exception.
-|-
-|}
-
-== Pass/fail tests ==
-Tests are not levels per se. When possible, they either pass or fail. It's similar to a walk/don't walk traffic sign.
-
-{| class="wikitable"
-|-
-! Level
-! Coding rationale
-! Definition & expectations
-|-
-! <span style="background-color: #14892c; border-radius: .25em; color: #ffffff; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">PASS</span>
-|
-* Green generally means acceptance, allowance such as the traffic sign "Walk".
-|
-* Means a test successfully passed.
-* There is no "almost passed": test must completely pass.
-|-
-! <span style="background-color: #d04437; border-radius: .25em; color: #ffffff; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">FAIL</span>
-|
-* Red generally means refusal, denial, such as the traffic sign "Don't walk".
-|
-* Means a test did not pass.
-|-
-|}
-
-== Document Status Codes ==
-These are used in the header of every document to clearly signify its current status.
-
-{| class="wikitable"
-|-
-! Level
-! Definition & expectations
-|-
-! <span style="background-color: #14892c; border-radius: .25em; color: #ffffff; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">READY</span>
-|
-* Means the document is ready for user consumption and is expected to be followed.
-|-
-! <span style="background-color: #ffd351; border-radius: .25em; color: #594300; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">DRAFT</span>
-|
-* Means the document is in progress or does not cover all cases.
-* You may follow this document for guidance, at your own risk.
-|-
-! <span style="background-color: #d04437; border-radius: .25em; color: #ffffff; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">NOT READY</span>
-|
-* Means the document should not be followed right now.
-|-
-|}
-
-== Scoring levels ==
-These levels are used to score general effectiveness. Most commonly, these levels are used to score countermeasure effectiveness (controls) in security reports.
-
-Four levels are used to align with other security related levels, such as risk levels. Note these levels do not signify risk, and are more intended to provide a grade for a particular objective.
-
-{| class="wikitable"
-|-
-! Level
-! Definition & expectations
-|-
-
-! <span style="background-color: #14892c; border-radius: .25em; color: #ffffff; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">✯✯✯✯</span>
-|
-''Highest possible grade.''
-
-* All intentions of objective met.
-* Attention expected but not required.
-|-
-! <span style="background-color: #4a6785; border-radius: .25em; color: #000000; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">✯✯✯</span>
-|
-* Most intentions of objective met.
-* Some outliers require attention.
-* Immediate action not required.
-|-
-! <span style="background-color: #ffd351; border-radius: .25em; color: #594300; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">✯✯</span>
-|
-''Score may moderately contribute to risk.''
-
-* Minimal to moderate intentions of objective met
-* Attention and timely action are required
-* Potential blocker on initiative
-|-
-! <span style="background-color: #d04437; border-radius: .25em; color: #ffffff; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">✯</span>
-|
-''Lowest possible grade, score may greatly contribute to risk.''
-
-* Zero to minimal intentions of objective met.
-* Immediate attention and action are required.
-* Score likely to block initiative.
-|-
-|}
-
-The values may be scored ordinally, but should be represented visually (using star symbols) for presentation purposes. Where scores are desired to be fed into other metrics (e.g. risk calculations) the scores may be inverted (e.g. a 1 becomes a 4) to represent an impact score (risk datapoint).
-
-== Levels of security provided (by service) ==
-This should be used for Mozilla provided or hosted services as well as externally provided services (SaaS, etc.).
-
-{| class="wikitable"
-|-
-! Security level provided (impacts mentioned are from [[Security/Risk management/Rapid Risk Assessment|Rapid Risk Assessment]]
-! Definition & expectations
-|-
-! <span style="background-color: #cccccc; border-radius: .25em; color: #000000; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">LOW</span>
-|
-* This service provides very little security controls and/or practices - it is known as carrying more risk.
-* Is not expected to provide effective security controls.
-* May only be used by  <span style="background-color: #cccccc; border-radius: .25em; color: #000000; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">LOW</span> risk impact services.
-|-
-! <span style="background-color: #4a6785; border-radius: .25em; color: #ffffff; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">MEDIUM</span>
-|
-* This service uses best practices security-wise. Follows all standards and guidelines.
-* May be used with most services that do not require specific security controls, or <span style="background-color: #4a6785; border-radius: .25em; color: #ffffff; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">MEDIUM</span> (or lower) risk impact services.
-|-
-! <span style="background-color: #ffd351; border-radius: .25em; color: #594300; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">HIGH</span>
-|
-* In addition to the <span style="background-color: #4a6785; border-radius: .25em; color: #ffffff; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">MEDIUM</span> level, this service provides:
-** Multiple security layers across the board.
-** Has dedicated security contacts/teams.
-** Gets tested regularly and has a good track record.
-* May be used for services with <span style="background-color: #ffd351; border-radius: .25em; color: #594300; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">HIGH</span> (or lower) risk impact.
-|-
-! <span style="background-color: #d04437; border-radius: .25em; color: #ffffff; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">MAXIMUM</span>
-|
-* In addition to the high level, this service does exceptionally well in the security space and is well-known for properly implementing the best controls, processes, etc.
-* Advanced tools are used to ensure strong and granular data separation (such as system-level RBAC).
-* May be used to support any other service, including <span style="background-color: #d04437; border-radius: .25em; color: #ffffff; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">MAXIMUM</span> risk impact services.
-|-
-|}
+* You site scored <span style="background-color: #ffd351; border-radius: .25em; color: #594300; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">C</span> to the HTTP observatory tests, it is at <span style="background-color: #4a6785; border-radius: .25em; color: #ffffff; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">MEDIUM Risk</span>.
+* You have 1 immediately exploitable RCE vulnerability of maximum impact and are at <span style="background-color: #d04437; border-radius: .25em; color: #ffffff; display: inline-block; font-weight: bold; margin: .1em 0; min-width: 6em; padding: .05em .5em; text-transform: uppercase; text-align: center;">MAXIMUM Risk</span>.


### PR DESCRIPTION
…la/wikimo_content/issues/50 for full discussion.

The new standard level page uses the same labels and expectations as the initial page, however:

- it clearly splits risk levels (the standard levels) apart from any other levels (documentation readyness, scoring,
  pass/fail tests, etc.)
- it more clearly spells out levels expectations
- it allows for indicating the level names in the label "LOW Risk", "LOW Impact", etc. vs just "LOW", which enhances
  clarity for the reader/avoids confusion
- It changes the exception time to more closely match risk instead of impact

All in all, it helps ensuring we always focus on risk (not impact, not likelihood, not scores, etc.) when using the
levels, though you can have both scores and risk (or impact and risk, or anything of your choosing as long as risk is
ALSO included).

This allows us for directly correlating measured risk between services (for ex "MEDIUM Risk" web app resulting from
observatories scans and "LOW risk" system state resulting from MIG + vuln scans vs "HIGH Impact" in an RRA mean the
complete service is currently at MEDIUM or HIGH Risk and can be represented this way in the risk heatmap).