### PR TITLE
CSP example correction

### DIFF
--- a/Security/Guidelines/Web_Security.mediawiki
+++ b/Security/Guidelines/Web_Security.mediawiki
@@ -363,7 +363,7 @@ Content-Security-Policy: default-src 'self'; img-src 'self' https://i.imgur.com;
 <pre># Disable unsafe inline/eval and plugins, only load scripts and stylesheets from same origin, fonts from google,
 # and images from same origin and imgur. Sites should aim for policies like this.
 Content-Security-Policy: default-src 'none'; font-src 'https://fonts.googleapis.com';
-                             img-src 'self' https://i.imgur.com; object-src 'none'; script-src 'self'; style-src 'self'</pre>
+                             img-src 'self' https://i.imgur.com; script-src 'self'; style-src 'self'</pre>
 
 <pre># Pre-existing site that uses too much inline code to fix
 # but wants to ensure resources are loaded only over https and disable plugins


### PR DESCRIPTION
The Content Security Policy, since version 1.0, lets object-src inherit from default-src if left unspecified.
In the example I'm correcting, the object-src directive is redundant, because it inherits the same value from default-src.