### PR TITLE
Make sure entire InfoSec team reflected on Wiki

### DIFF
--- a/Security/InfoSec.mediawiki
+++ b/Security/InfoSec.mediawiki
@@ -11,7 +11,7 @@ Infosec assists Mozillians in defining and operating security controls to ensure
 = Contact =
 Email us at '''infosec''' [at] mozilla.com. For confidential information, encrypt your email using our public PGP: [https://gpg.mozilla.org/pks/lookup?op=get&search=0xBC17301B491B3F21 Operations Security (Mozilla Security Assurance)] .
 
-For security incidents, file a bug in Bugzilla under the product/component [https://bugzilla.mozilla.org/enter_bug.cgi?product=Enterprise%20Information%20Security&component=Investigation] or [https://bugzilla.mozilla.org/enter_bug.cgi?product=Enterprise%20Information%20Security&component=Incident].
+For security incidents, file a bug in Bugzilla under the product/component [https://bugzilla.mozilla.org/enter_bug.cgi?product=Enterprise%20Information%20Security&component=Investigation] or [https://bugzilla.mozilla.org/enter_bug.cgi?product=Enterprise%20Information%20Security&component=Incident]. Or email '''foxsignal''' [at] mozilla.com.
 
 Our IRC channel is #infosec or #security at [irc://irc.mozilla.org/security irc.mozilla.org].
 

--- a/Security/InfoSec.mediawiki
+++ b/Security/InfoSec.mediawiki
@@ -17,16 +17,19 @@ Our IRC channel is #infosec or #security at [irc://irc.mozilla.org/security irc.
 
 = Members =
 [[File:OpSec.png|left|200px]]
-* [https://mozillians.org/en-US/u/kang/ Guillaume Destuynder] [:kang]
-* [https://mozillians.org/en-US/u/michalpurzynski/ Michal Purzynski] [:michal`]
-* [https://mozillians.org/en-US/u/jvehent/ Julien Vehent] [:ulfr]
 * [https://mozillians.org/en-US/u/jbryner/ Jeff Bryner] [:jeff]
-* [https://mozillians.org/en-US/u/gene/ Gene Wood] [:gene]
 * [https://mozillians.org/en-US/u/alm/ Aaron Meihm] [:alm]
-* [https://mozillians.org/en-US/u/jclaudius/ Jonathan Claudius] [:claudijd]
-* [https://mozillians.org/en-US/u/april/ April King] [:April]
 * [https://mozillians.org/en-US/u/phrozyn/ Alicia Smith] [:phrozyn]
 * [https://mozillians.org/en-US/u/akrug/ Andrew Krug] [:andrew]
+* [https://mozillians.org/en-US/u/april/ April King] [:April]
+* [https://mozillians.org/en-US/u/bmyers/ Brandon Myers] [:pwnbus]
+* [https://mozillians.org/ Caglar Ulucenk] [:Cag]
+* [https://mozillians.org/en-US/u/gene/ Gene Wood] [:gene]
+* [https://mozillians.org/en-US/u/kang/ Guillaume Destuynder] [:kang]
+* [https://mozillians.org/en-US/u/jclaudius/ Jonathan Claudius] [:claudijd]
+* [https://mozillians.org/en-US/u/jabba/ Justin Dow] [:jabba]
+* [https://mozillians.org/en-US/u/michalpurzynski/ Michal Purzynski] [:michal`]
+* [https://mozillians.org/en-US/u/tweir/ Tristan Weir] [:weir]
 
 = Service Catalog =
 


### PR DESCRIPTION
This page was missing several team members. I have added them.
Also, this page was missing an escalation path for reporting a security incident via email.