### PR TITLE
Harmonizing language: 2 factor <> two-factor

### DIFF
--- a/IAM/Frequently_asked_questions.mediawiki
+++ b/IAM/Frequently_asked_questions.mediawiki
@@ -6,21 +6,21 @@
 system that Mozilla manage logins to various web properties and systems.
 
 Usually, you'd use Mozilla IAM as Mozilla Staff, or as a contributor with access to the tools and resources Mozilla uses day to day.
-An example of that would be our Discourse instance: http://discourse.mozilla-community.org/
+An example of that would be our Discourse instance: http://discourse.mozilla.org/
 
 Mozilla IAM is '''not''' Firefox Accounts, Persona or part of any Mozilla Product.
 
 ==== '''Q''': ''How do I login with Mozilla IAM?'' ====
 
 Mozilla IAM supports various login methods, such as "LDAP" (Staff logins), GitHub social login, Google social login and email login (which we call "passwordless").
-Certain methods support and enforce the use of a 2nd factor for authentication and may grant access to more sensitive services.
+Certain methods support and enforce the use of two-factor authentication (2FA) and may grant access to more sensitive services.
 
 ==== '''Q''': ''Why is my login failing with an error message telling me to use "GitHub/Google/LDAP/etc" instead?'' ====
 
 If your login (your primary email address used by Mozilla IAM) matches an existing account which provides higher
 security, we require that you use the most secure method available to login.
 
-Example: LDAP uses 2 factor authentication to verify a user's identity and is safer than using email login
+Example: LDAP uses two-factor authentication to verify a user's identity and is safer than using email login
 ("passwordless").
 
 ==== '''Q''': ''Why do you support email login ("passwordless") if it's less safe than other methods?'' ====
@@ -30,17 +30,17 @@ Email login ("passwordless") is our current solution for this use case. Some app
 
 ==== '''Q''': ''I would like access to specific groups, such as the NDA group, but it requires me to use a different login method, why?'' ====
 
-We only allow login, or authentication methods that can verifiably require 2 factor authentication in order to join any group that may grant you access to data that is not public, such as what we call [https://wiki.mozilla.org/Security/Data_Classification STAFF CONFIDENTIAL data].
+We only allow login, or authentication methods that can verifiably require two-factor authentication (2FA) in order to join any group that may grant you access to data that is not public, such as what we call [https://wiki.mozilla.org/Security/Data_Classification STAFF CONFIDENTIAL data].
 At the time of writing, only LDAP, Google accounts that use our LDAP backend (i.e. '''not''' '@gmail.com' accounts) and GitHub account support this functionality.
 
-Example: you could get a GitHub account with 2nd factor authentication enabled. Here's some documentation on how to do this: https://help.github.com/articles/about-two-factor-authentication/
+Example: you could get a GitHub account with two-factor authentication enabled. Here's some documentation on how to do this: https://help.github.com/articles/about-two-factor-authentication/
 
 If more authentication methods add support for this in the future and seem to be otherwise safe, we'll gladly allow them as well.
 
 ==== '''Q''': ''I used to use email login ("passwordless") to access [https://wiki.mozilla.org/Security/Data_Classification STAFF CONFIDENTIAL data] with my NDA'd account, but I lost access'' ====
 
 We no longer allow email logins to access non-PUBLIC data (see previous FAQ item as well).
-In order to regain access, please use a login method that supports 2nd factor authentication such as GitHub (with 2nd factor enabled). Here's some documentation on how to do this: https://help.github.com/articles/about-two-factor-authentication/
+In order to regain access, please use a login method that supports two-factor authentication (2FA) such as GitHub. Here's some documentation on how to do this: https://help.github.com/articles/about-two-factor-authentication/
 
 ==== '''Q''': ''Where is the source code, documentation, etc. for all Mozilla IAM Projects?'' ====
 


### PR DESCRIPTION
Using the same language as Github (https://help.github.com/articles/securing-your-account-with-two-factor-authentication-2fa) for 2FA.
Also updated the  Discourse link.