### PR TITLE
Fix JSON error caused by bad path

### DIFF
--- a/sync.json.inc
+++ b/sync.json.inc
@@ -1,7 +1,7 @@
 {
 	"username": "",
 	"password": "",
-	"site": "wiki.mozilla.org/api.php",
+	"site": "wiki.mozilla.org",
 	"useragent": "Infosec wiki updater, based on mwclient",
 	"repos": "https://github.com/mozilla/wikimo_content",
 	"basedir" : ".",

--- a/sync.py
+++ b/sync.py
@@ -26,7 +26,7 @@ import getopt
 import subprocess
 
 def connect(config):
-    site = mwclient.Site(('https', config['site']), clients_useragent=config['useragent'])
+    site = mwclient.Site((config['site']), clients_useragent=config['useragent'])
     site.login(config['username'], config['password'])
     return site
 

--- a/sync.py
+++ b/sync.py
@@ -26,7 +26,7 @@ import getopt
 import subprocess
 
 def connect(config):
-    site = mwclient.Site((config['site']), clients_useragent=config['useragent'])
+    site = mwclient.Site((config['site']), path='/', clients_useragent=config['useragent'])
     site.login(config['username'], config['password'])
     return site
 


### PR DESCRIPTION
mwclient now assumes a path prefix of `/w/` which causes an error. This fixes that path in the example and asserts a path of `/` in the code
Fixes #133